### PR TITLE
Added Kerberos.NET.PortableDns support

### DIFF
--- a/WinRm.Cli/Commands/DebugCommandOptions.cs
+++ b/WinRm.Cli/Commands/DebugCommandOptions.cs
@@ -3,7 +3,7 @@
     using CommandLine;
     using WinRm.NET;
 
-    [Verb("debug", HelpText = "Decrypt a WinRM payload given an athenticate message and password")]
+    [Verb("debug", HelpText = "Decrypt a WinRM payload given an authenticate message and password")]
     public class DebugCommandOptions : ICliCommand
     {
         [Option('a', "authenticate_message", Required = true, HelpText = "Base64-encoded authenticate message from HTTP header")]

--- a/WinRm.Cli/Commands/RunCommandOptions.cs
+++ b/WinRm.Cli/Commands/RunCommandOptions.cs
@@ -42,6 +42,9 @@
         [Option('S', "spn", Required = false, HelpText = "Specify the Kerberos SPN of the host target.")]
         public string? Spn { get; set; }
 
+        [Option('D', "dns", Required = false, HelpText = "Specify the DNS server to use.")]
+        public string? DnsServer { get; set; }
+
         public async Task<int> Execute()
         {
             RunCommandOptions opts = this;
@@ -66,8 +69,9 @@
                     .WithUser(opts.UserName)
                     .WithPassword(opts.Password!)
                     .WithRealmName(opts.RealmName)
-                    .WithKdc(opts.Kdc!)
+                    .WithKdc(opts.Kdc)
                     .WithSpn(opts.Spn)
+                    .WithDns(opts.DnsServer)
                     .Build(opts.HostName),
                 AuthType.Ntlm => sessionBuilder.WithNtlm()
                     .WithUser(opts.UserName)

--- a/WinRm.NET/IWinRmSessionBuilder.cs
+++ b/WinRm.NET/IWinRmSessionBuilder.cs
@@ -26,10 +26,12 @@
     public interface IWinRmKerberosSessionBuilder
         : IWinRmSessionBuilder<IWinRmKerberosSessionBuilder>
     {
-        IWinRmKerberosSessionBuilder WithRealmName(string realm);
+        IWinRmKerberosSessionBuilder WithRealmName(string? realm);
 
-        IWinRmKerberosSessionBuilder WithKdc(string address);
+        IWinRmKerberosSessionBuilder WithKdc(string? address);
 
         IWinRmKerberosSessionBuilder WithSpn(string? spn);
+
+        IWinRmKerberosSessionBuilder WithDns(string? dns);
     }
 }

--- a/WinRm.NET/Internal/Kerberos/WinRmKerberosBuilder.cs
+++ b/WinRm.NET/Internal/Kerberos/WinRmKerberosBuilder.cs
@@ -9,6 +9,7 @@
         private string? realm;
         private string? kdc;
         private string? spn;
+        private string? dns;
 
         public WinRmKerberosBuilder(WinRmSessionBuilder parent)
             : base(AuthType.Kerberos, parent)
@@ -22,22 +23,13 @@
                 throw new InvalidOperationException("User must be specified");
             }
 
-            if (realm == null)
-            {
-                throw new InvalidOperationException("Realm must be specified for Kerberos authentication.");
-            }
-
-            if (kdc == null)
-            {
-                throw new InvalidOperationException("KDC address must be specified for Kerberos authentication.");
-            }
-
             var securityEnvelope = new KerberosSecurityEnvelope(
                 Parent.Logger,
                 new Credentials(User, Password!),
-                realm ?? throw new InvalidOperationException("Realm must be specified when AuthType is Kerberos."),
-                kdc ?? throw new InvalidOperationException("KDC address must be specified when AuthType is Kerberos."),
-                spn);
+                realm,
+                kdc,
+                spn,
+                dns);
 
             if (this.Parent.LoggerFactory != null)
             {
@@ -51,13 +43,13 @@
                 port);
         }
 
-        public IWinRmKerberosSessionBuilder WithRealmName(string realm)
+        public IWinRmKerberosSessionBuilder WithRealmName(string? realm)
         {
             this.realm = realm;
             return this;
         }
 
-        public IWinRmKerberosSessionBuilder WithKdc(string address)
+        public IWinRmKerberosSessionBuilder WithKdc(string? address)
         {
             this.kdc = address;
             return this;
@@ -66,6 +58,12 @@
         public IWinRmKerberosSessionBuilder WithSpn(string? spn)
         {
             this.spn = spn;
+            return this;
+        }
+
+        public IWinRmKerberosSessionBuilder WithDns(string? dns)
+        {
+            this.dns = dns;
             return this;
         }
     }

--- a/WinRm.NET/WinRm.NET.csproj
+++ b/WinRm.NET/WinRm.NET.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Kerberos.NET" Version="4.6.116" />
+    <PackageReference Include="Kerberos.NET.PortableDns" Version="4.6.116" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="9.0.5" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">


### PR DESCRIPTION
Now you can use DNS as a fallback for determining the realm and finding the KDC.  You don't have to specify quite some many parameters to the CLI tool.